### PR TITLE
스크랩 URL 수정 및 CORS 오류

### DIFF
--- a/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/CorsConfig.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/CorsConfig.java
@@ -3,8 +3,10 @@ package com.hanyang.dataportal.core.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+import java.util.List;
 
 @Configuration
 public class CorsConfig {
@@ -21,5 +23,18 @@ public class CorsConfig {
         source.registerCorsConfiguration("/**", config);
 
         return new CorsFilter(source);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("http://localhost:3000/");
+        config.setAllowedMethods(List.of("GET", "POST", "DELETE", "PUT"));
+        config.setAllowedHeaders(List.of("*"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig{
 //                    authorizeRequests.requestMatchers(HttpMethod.POST,"/api/dataset/**").hasRole("ADMIN");;
 //                    authorizeRequests.requestMatchers(HttpMethod.PUT,"/api/dataset/**").hasRole("ADMIN");
 //                    authorizeRequests.requestMatchers(HttpMethod.DELETE,"/api/dataset/**").hasRole("ADMIN");
-                    authorizeRequests.requestMatchers(HttpMethod.GET, "api/scrap/**").hasRole("USER");
+                    authorizeRequests.requestMatchers(HttpMethod.GET, "api/scrap/**").authenticated();
                     authorizeRequests.requestMatchers(HttpMethod.POST, "/api/scrap/dataset/**").hasRole("USER");
                     authorizeRequests.requestMatchers(HttpMethod.DELETE, "/api/scrap/dataset/**").hasRole("USER");
                     authorizeRequests.anyRequest().permitAll(); // 그 외의 요청은 다 허용

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.hanyang.dataportal.core.config;
 
 import com.hanyang.dataportal.core.component.CustomAuthenticationEntryPoint;
 import com.hanyang.dataportal.core.filter.JwtAuthenticationFilter;
+import com.hanyang.dataportal.user.domain.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -44,6 +45,9 @@ public class SecurityConfig{
 //                    authorizeRequests.requestMatchers(HttpMethod.POST,"/api/dataset/**").hasRole("ADMIN");;
 //                    authorizeRequests.requestMatchers(HttpMethod.PUT,"/api/dataset/**").hasRole("ADMIN");
 //                    authorizeRequests.requestMatchers(HttpMethod.DELETE,"/api/dataset/**").hasRole("ADMIN");
+                    authorizeRequests.requestMatchers(HttpMethod.GET, "api/scrap/**").hasRole("USER");
+                    authorizeRequests.requestMatchers(HttpMethod.POST, "/api/scrap/dataset/**").hasRole("USER");
+                    authorizeRequests.requestMatchers(HttpMethod.DELETE, "/api/scrap/dataset/**").hasRole("USER");
                     authorizeRequests.anyRequest().permitAll(); // 그 외의 요청은 다 허용
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 @EnableWebSecurity
 @Configuration
@@ -23,12 +24,14 @@ public class SecurityConfig{
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CorsConfigurationSource corsConfigurationSource;
 
     // security 6.1 최신버전으로 문법을 조금 다르게 사용해야함.
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer.configurationSource(corsConfigurationSource))
 
                 //폼 로그인 안함
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
@@ -49,8 +49,8 @@ public class SecurityConfig{
 //                    authorizeRequests.requestMatchers(HttpMethod.PUT,"/api/dataset/**").hasRole("ADMIN");
 //                    authorizeRequests.requestMatchers(HttpMethod.DELETE,"/api/dataset/**").hasRole("ADMIN");
                     authorizeRequests.requestMatchers(HttpMethod.GET, "api/scrap/**").authenticated();
-                    authorizeRequests.requestMatchers(HttpMethod.POST, "/api/scrap/dataset/**").hasRole("USER");
-                    authorizeRequests.requestMatchers(HttpMethod.DELETE, "/api/scrap/dataset/**").hasRole("USER");
+                    authorizeRequests.requestMatchers(HttpMethod.POST, "/api/scrap/dataset/**").authenticated();
+                    authorizeRequests.requestMatchers(HttpMethod.DELETE, "/api/scrap/dataset/**").authenticated();
                     authorizeRequests.anyRequest().permitAll(); // 그 외의 요청은 다 허용
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
@@ -48,9 +48,9 @@ public class SecurityConfig{
 //                    authorizeRequests.requestMatchers(HttpMethod.POST,"/api/dataset/**").hasRole("ADMIN");;
 //                    authorizeRequests.requestMatchers(HttpMethod.PUT,"/api/dataset/**").hasRole("ADMIN");
 //                    authorizeRequests.requestMatchers(HttpMethod.DELETE,"/api/dataset/**").hasRole("ADMIN");
-                    authorizeRequests.requestMatchers(HttpMethod.GET, "api/scrap/**").hasRole("ADMIN");
-                    authorizeRequests.requestMatchers(HttpMethod.POST, "/api/scrap/dataset/**").hasRole("ADMIN");
-                    authorizeRequests.requestMatchers(HttpMethod.DELETE, "/api/scrap/dataset/**").hasRole("ADMIN");
+                    authorizeRequests.requestMatchers(HttpMethod.GET, "api/scrap/**").hasRole("USER");
+                    authorizeRequests.requestMatchers(HttpMethod.POST, "/api/scrap/dataset/**").hasRole("USER");
+                    authorizeRequests.requestMatchers(HttpMethod.DELETE, "/api/scrap/dataset/**").hasRole("USER");
                     authorizeRequests.anyRequest().permitAll(); // 그 외의 요청은 다 허용
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/core/config/SecurityConfig.java
@@ -48,9 +48,9 @@ public class SecurityConfig{
 //                    authorizeRequests.requestMatchers(HttpMethod.POST,"/api/dataset/**").hasRole("ADMIN");;
 //                    authorizeRequests.requestMatchers(HttpMethod.PUT,"/api/dataset/**").hasRole("ADMIN");
 //                    authorizeRequests.requestMatchers(HttpMethod.DELETE,"/api/dataset/**").hasRole("ADMIN");
-                    authorizeRequests.requestMatchers(HttpMethod.GET, "api/scrap/**").authenticated();
-                    authorizeRequests.requestMatchers(HttpMethod.POST, "/api/scrap/dataset/**").authenticated();
-                    authorizeRequests.requestMatchers(HttpMethod.DELETE, "/api/scrap/dataset/**").authenticated();
+                    authorizeRequests.requestMatchers(HttpMethod.GET, "api/scrap/**").hasRole("ADMIN");
+                    authorizeRequests.requestMatchers(HttpMethod.POST, "/api/scrap/dataset/**").hasRole("ADMIN");
+                    authorizeRequests.requestMatchers(HttpMethod.DELETE, "/api/scrap/dataset/**").hasRole("ADMIN");
                     authorizeRequests.anyRequest().permitAll(); // 그 외의 요청은 다 허용
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/user/controller/ScrapController.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/user/controller/ScrapController.java
@@ -56,7 +56,7 @@ public class ScrapController {
      * @return
      */
     @Operation(summary = "로그인 유저의 새로운 스크랩 생성")
-    @PostMapping("/api/dataset/{datasetId}/scrap")
+    @PostMapping("/api/scrap/dataset/{datasetId}")
     public ResponseEntity<ApiResponse<?>> createScrap(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long datasetId) {
         Scrap scrap = scrapService.create(userDetails.getUsername(), datasetId);
         ResScrapDto resScrapDto = new ResScrapDto(scrap);
@@ -70,14 +70,14 @@ public class ScrapController {
      * @return
      */
     @Operation(summary = "로그인 유저의 특정 스크랩 내역 삭제")
-    @DeleteMapping("/api/dataset/{datasetId}/scrap")
+    @DeleteMapping("/api/scrap/dataset/{datasetId}")
     public ResponseEntity<ApiResponse<?>> deleteScrap(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long datasetId) {
         scrapService.delete(userDetails.getUsername(), datasetId);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
     @Operation(summary = "특정 데이터셋에 대한 유저 스크랩 여부")
-    @GetMapping("/api/dataset/{datasetId}/scrap")
+    @GetMapping("/api/scrap/dataset/{datasetId}")
     public ResponseEntity<ApiResponse<?>> isScrap(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long datasetId) {
         return ResponseEntity.ok(ApiResponse.ok(new ResIsScrapDto(scrapService.isUserScrap(userDetails.getUsername(),datasetId))));
     }


### PR DESCRIPTION
## 작업내용
- 스크랩 api url 수정
    - 데이터셋 url과 서로 중복되므로 스크랩 url을 `api/scrap/~` 로 수정
- CORS 오류 해결
    - `SecurityConfig` 내에서 `requestMatcher` 적용 이후 CORS 에러가 발생
        - 원인 예측: `requestMatcher`에 명시한 권한을 확인하는 과정에서 CORS 적용 없이 로직이 실행되면서 해당 오류가 발생하는 것이 아닐까?

## TODO
- `requestMatcher` 적용시 CORS 오류 발생 원인 조사
    - 적용 이전에는 발생하지 않았음