### PR TITLE
[fix] 토큰 관련 오류

### DIFF
--- a/dataportal-web/src/main/java/com/hanyang/dataportal/core/jwt/component/JwtTokenProvider.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/core/jwt/component/JwtTokenProvider.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.Date;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Component
@@ -59,16 +58,6 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-//    /**
-//     * refresh token 생성 메서드
-//     * @param username
-//     */
-//     private String generateRefreshToken(final String username, final Long expiredInMillisecond) {
-//        final String refreshToken = UUID.randomUUID().toString();
-//        redisService.setCode(username, refreshToken, expiredInMillisecond);
-//        return refreshToken;
-//    }
-
     private String generateRefreshToken(
             final Authentication authentication,
             final boolean isAutoLogin,
@@ -105,9 +94,8 @@ public class JwtTokenProvider {
             return ResponseCookie.from(REFRESH_COOKIE_KEY, refreshToken)
                     .maxAge(0) // 쿠키 삭제
                     .httpOnly(true)
-                    //TODO: https 배포 이후 true로 변경
-                    .secure(false)
-                    .sameSite("Lax")
+                    .secure(true)
+                    .sameSite("None")
                     .path("/")
                     .build();
         }
@@ -115,9 +103,8 @@ public class JwtTokenProvider {
             return ResponseCookie.from(REFRESH_COOKIE_KEY, refreshToken)
                     .maxAge(SESSION_COOKIE_MAX_AGE) // 세션쿠키
                     .httpOnly(true)
-                    //TODO: https 배포 이후 true로 변경
-                    .secure(false)
-                    .sameSite("Lax")
+                    .secure(true)
+                    .sameSite("None")
                     .path("/")
                     .build();
         }
@@ -125,9 +112,8 @@ public class JwtTokenProvider {
         return ResponseCookie.from(REFRESH_COOKIE_KEY, refreshToken)
                 .maxAge(duration)
                 .httpOnly(true)
-                //TODO: https 배포 이후 true로 변경
-                .secure(false)
-                .sameSite("Lax")
+                .secure(true)
+                .sameSite("None")
                 .path("/")
                 .build();
     }

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/user/dto/req/ReqOauthDto.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/user/dto/req/ReqOauthDto.java
@@ -2,9 +2,11 @@ package com.hanyang.dataportal.user.dto.req;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class ReqOauthDto {
     private String code;
 }


### PR DESCRIPTION
## 작업내용
- 배포 서버에서 `set-cookie` 헤더가 동작하지 않음
    - `same-site` 옵션이 원인이라고 예상하여 이 값을 `Lax` -> `None`으로 수정
- 이전 작업에서 `ReqOauthDto`의 `@NoArgsConstructor` 어노테이션을 삭제했는데, 이로 인해 400 에러가 발생하였음
    - 해당 어노테이션을 다시 추가
    - 컨트롤러가 요청을 받을 때, argument가 없는 생성자로 `ReqOauthDto` 객체를 생성해서 발생했던 오류인 것으로 추정

## TODO
컨트롤러가 api 요청을 받을 때, **자바 객체 형태의 body를 받는 경우의 처리 과정** 조사하기
- `JSON` -> `자바 객체` 형태 변환 과정에서 argument가 없는 생성자를 호출하는 것 같다

main 브랜치에 머지 후, 배포 서버에서 `set-cookie`(ex. 로그인 / 로그아웃)가 잘 작동하는지 확인할 것