### PR TITLE
[Fix] my/list 경로에서 userDetails 값이 NULL로 반환 + Question 로직에서 게시글 수정시 신규 생성

### DIFF
--- a/dataportal-web/src/main/java/com/hanyang/dataportal/core/filter/JwtAuthenticationFilter.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/core/filter/JwtAuthenticationFilter.java
@@ -37,7 +37,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 "/api/dataset",
                 "/api/datasets",
                 "/api/notices/list",
-                "/api/questions/list"
         };
         final String path = request.getRequestURI();
         return Arrays.stream(excludes).anyMatch(path::startsWith);

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/qna/controller/AnswerController.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/qna/controller/AnswerController.java
@@ -24,7 +24,7 @@ public class AnswerController {
     private final AnswerService answerService;
 
     @Operation(summary = "질문에 대한 답변생성")
-    @PostMapping(value = "/" , name = "답변하기")
+    @PostMapping(value = "/")
     public ResponseEntity<ApiResponse<?>> saveAnswer(@RequestBody ReqAnswerDto reqAnswerDto, Long questionId, @AuthenticationPrincipal UserDetails userDetails) {
         Answer answer = reqAnswerDto.toEntity();
         String username = userDetails.getUsername();
@@ -34,7 +34,7 @@ public class AnswerController {
     }
 
     @Operation(summary = "질문에 대한 답변수정")
-    @PutMapping(value = "/{answerId}", name = "답변수정")
+    @PutMapping(value = "/{answerId}")
     public ResponseEntity<ApiResponse<?>> update(@RequestParam ReqAnswerDto reqAnswerDto, @PathVariable Long answerId, @AuthenticationPrincipal UserDetails userDetails) {
 
         Answer answer = reqAnswerDto.toEntity();
@@ -46,7 +46,7 @@ public class AnswerController {
     }
 
     @Operation(summary = "질문에 대한 답변삭제")
-    @DeleteMapping(value = "/{answerId}" , name= "답변삭제")
+    @DeleteMapping(value = "/{answerId}" )
     public ResponseEntity<ApiResponse<?>> delete(@PathVariable long answerId, @AuthenticationPrincipal UserDetails userDetails) {
         String userName = userDetails.getUsername();
         answerService.delete(answerId, userName);
@@ -55,7 +55,7 @@ public class AnswerController {
     }
 
     @Operation(summary = "질문에 대한 답변상세 보기")
-    @GetMapping(value = "/{answerId}", name ="답변 상세보기")
+    @GetMapping(value = "/{answerId}")
     public ResponseEntity<ApiResponse<?>> getDetailAnswer(@PathVariable Long answerId) {
         Answer answer = answerService.getDetailAnswer(answerId);
         ResAnswerDetailDto resAnswerDto = ResAnswerDetailDto.toDetailDto(answer);
@@ -63,7 +63,7 @@ public class AnswerController {
     }
 
     @Operation(summary = "질문글 리스트조회")
-    @GetMapping(value = "/list", name = "질문 리스트보기")
+    @GetMapping(value = "/list")
     public ResponseEntity<ApiResponse<?>> getTodoAnswerList(@RequestParam(value = "page", required = false, defaultValue = "1") int pageNum,
                                                             @RequestParam(value =  "size", defaultValue = "10")int listSize)  {
         Page<ResAnswerListDto> answerList = answerService.getAnswerList(pageNum, listSize);

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/qna/controller/QuestionController.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/qna/controller/QuestionController.java
@@ -25,7 +25,7 @@ public class QuestionController {
     private final QuestionService questionService;
 
     @Operation(summary = "질문글 작성")
-    @PostMapping(value = "/", name = "질문하기 API (생성) ")
+    @PostMapping(value = "/")
     public ResponseEntity<ApiResponse<ResQuestionDto>> createQuestion(@AuthenticationPrincipal UserDetails userDetails, @RequestBody ReqQuestionDto reqQuestionDto) {
         Question question = reqQuestionDto.toEntity();
         String username = userDetails.getUsername();
@@ -35,7 +35,7 @@ public class QuestionController {
     }
 
     @Operation(summary = "질문글 수정")
-    @PutMapping(value = "/{questionId}", name = "질문하기 API (수정)")
+    @PutMapping(value = "/{questionId}")
     public ResponseEntity<ApiResponse<ResQuestionDto>> updateQuestion(@RequestBody ReqQuestionDto reqQuestionDto, @PathVariable long questionId) {
         Question question = reqQuestionDto.toUpdateEntity();
         questionService.updateQuestion(question, questionId);
@@ -44,7 +44,7 @@ public class QuestionController {
     }
 
     @Operation(summary = "질문글 삭제")
-    @DeleteMapping(value = "/{questionId}", name = "질문하기 API (삭제)")
+    @DeleteMapping(value = "/{questionId}")
     public ResponseEntity<ApiResponse<?>> deleteQuestion(@PathVariable long questionId, @AuthenticationPrincipal UserDetails userDetails) {
         questionService.deleteQuestion(questionId);
         return null;
@@ -70,7 +70,7 @@ public class QuestionController {
    }
 
     @Operation(summary = "질문글 조회 (상세)")
-    @GetMapping(value = "{questionId}", name = "질문 내역 상세보기 ")
+    @GetMapping(value = "{questionId}")
     public ResponseEntity<ApiResponse<ResQuestionDto>> getQuestion(@PathVariable Long questionId) {
         Question question = questionService.getDetailQuestion(questionId);
         ResQuestionDto resQuestionDto = ResQuestionDto.toQuestionDto(question);
@@ -78,7 +78,7 @@ public class QuestionController {
     }
 
     @Operation(summary = "나의 질문글 조회 (상세)")
-    @GetMapping(value = "list/my/{questionId}", name = "나의 질문 내역 상세보기 ")
+    @GetMapping(value = "list/my/{questionId}")
     public ResponseEntity<ApiResponse<ResQuestionDto>> getQuestion(@PathVariable long questionId) {
         Question question = questionService.getDetailQuestion(questionId);
         ResQuestionDto resQuestionDto = ResQuestionDto.toQuestionDto(question);

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/qna/controller/QuestionController.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/qna/controller/QuestionController.java
@@ -59,6 +59,7 @@ public class QuestionController {
    }
 
 
+
     @Operation(summary = "나의 질문글 내역리스트 (페이징)")
     @GetMapping("/list/my")
     public ResponseEntity<ApiResponse<List<ResQuestionListDto>>> getMyQuestionList(@AuthenticationPrincipal UserDetails userDetails, @RequestParam(value ="page", required = false, defaultValue = "1") int pageNum,

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/qna/controller/QuestionController.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/qna/controller/QuestionController.java
@@ -36,7 +36,8 @@ public class QuestionController {
 
     @Operation(summary = "질문글 수정")
     @PutMapping(value = "/{questionId}")
-    public ResponseEntity<ApiResponse<ResQuestionDto>> updateQuestion(@RequestBody ReqQuestionDto reqQuestionDto, @PathVariable long questionId) {
+    public ResponseEntity<ApiResponse<ResQuestionDto>> updateQuestion(@RequestBody ReqQuestionDto reqQuestionDto,
+                                                                      @PathVariable long questionId) {
         Question question = reqQuestionDto.toUpdateEntity();
         questionService.updateQuestion(question, questionId);
         ResQuestionDto resQuestionDto = ResQuestionDto.toQuestionDto(question);

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/qna/controller/QuestionController.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/qna/controller/QuestionController.java
@@ -23,17 +23,16 @@ import java.util.List;
 @RequestMapping("/api/questions")
 public class QuestionController {
     private final QuestionService questionService;
-
     @Operation(summary = "질문글 작성")
     @PostMapping(value = "/")
-    public ResponseEntity<ApiResponse<ResQuestionDto>> createQuestion(@AuthenticationPrincipal UserDetails userDetails, @RequestBody ReqQuestionDto reqQuestionDto) {
+    public ResponseEntity<ApiResponse<ResQuestionDto>> createQuestion(@AuthenticationPrincipal UserDetails userDetails,
+                                                                      @RequestBody ReqQuestionDto reqQuestionDto) {
         Question question = reqQuestionDto.toEntity();
         String username = userDetails.getUsername();
         questionService.save(question, username);
         ResQuestionDto resQuestionDto = ResQuestionDto.toQuestionDto((question));
         return ResponseEntity.ok(ApiResponse.ok(resQuestionDto));
     }
-
     @Operation(summary = "질문글 수정")
     @PutMapping(value = "/{questionId}")
     public ResponseEntity<ApiResponse<ResQuestionDto>> updateQuestion(@RequestBody ReqQuestionDto reqQuestionDto,
@@ -43,7 +42,6 @@ public class QuestionController {
         ResQuestionDto resQuestionDto = ResQuestionDto.toQuestionDto(question);
         return ResponseEntity.ok(ApiResponse.ok(resQuestionDto));
     }
-
     @Operation(summary = "질문글 삭제")
     @DeleteMapping(value = "/{questionId}")
     public ResponseEntity<ApiResponse<?>> deleteQuestion(@PathVariable long questionId, @AuthenticationPrincipal UserDetails userDetails) {
@@ -58,18 +56,15 @@ public class QuestionController {
         Page<ResQuestionListDto> resQuestionListDto = questionService.getQuestionList(pageNum,listSize);
         return ResponseEntity.ok(ApiResponse.ok(resQuestionListDto));
    }
-
-
-
     @Operation(summary = "나의 질문글 내역리스트 (페이징)")
     @GetMapping("/list/my")
-    public ResponseEntity<ApiResponse<List<ResQuestionListDto>>> getMyQuestionList(@AuthenticationPrincipal UserDetails userDetails, @RequestParam(value ="page", required = false, defaultValue = "1") int pageNum,
-                                                                                   @RequestParam(value = "size", defaultValue = "10") int listSize)
-   { String userName = userDetails.getUsername();
-    List<ResQuestionListDto> resQuestionListDtos = questionService.getMyQuestionList(userName,pageNum,listSize);
-    return ResponseEntity.ok(ApiResponse.ok(resQuestionListDtos));
+    public ResponseEntity<ApiResponse<List<ResQuestionListDto>>> getMyQuestionList(@AuthenticationPrincipal UserDetails userDetails,
+                                                                                   @RequestParam(value ="page", required = false, defaultValue = "1") int pageNum,
+                                                                                   @RequestParam(value = "size", defaultValue = "10") int listSize) {
+        String userName = userDetails.getUsername();
+        List<ResQuestionListDto> resQuestionListDtos = questionService.getMyQuestionList(userName,pageNum,listSize);
+        return ResponseEntity.ok(ApiResponse.ok(resQuestionListDtos));
    }
-
     @Operation(summary = "질문글 조회 (상세)")
     @GetMapping(value = "{questionId}")
     public ResponseEntity<ApiResponse<ResQuestionDto>> getQuestion(@PathVariable Long questionId) {
@@ -77,7 +72,6 @@ public class QuestionController {
         ResQuestionDto resQuestionDto = ResQuestionDto.toQuestionDto(question);
         return ResponseEntity.ok(ApiResponse.ok(resQuestionDto));
     }
-
     @Operation(summary = "나의 질문글 조회 (상세)")
     @GetMapping(value = "list/my/{questionId}")
     public ResponseEntity<ApiResponse<ResQuestionDto>> getQuestion(@PathVariable long questionId) {
@@ -85,5 +79,4 @@ public class QuestionController {
         ResQuestionDto resQuestionDto = ResQuestionDto.toQuestionDto(question);
         return ResponseEntity.ok(ApiResponse.ok(resQuestionDto));
     }
-
 }

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/qna/service/QuestionService.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/qna/service/QuestionService.java
@@ -30,16 +30,12 @@ public class QuestionService {
     }
 
     public Question save(Question question, String username) {
-        // 1. userservice에서 유저를 찾아
         User user = userService.findByEmail(username);
         question.setUser(user);
-        // 2. Question에 User 정보를 등록
-//        Question question = (Question) questionRepository.findByUser(username);
         return questionRepository.save(question);
     }
 
     public Question updateQuestion(Question reqUpdateQuestionDto, long questionId) {
-        // 1. userservice에서 유저를 찾아
         Optional<Question> updateQuestion = questionRepository.findById(questionId);
         if (updateQuestion.isPresent()) {
             questionRepository.save(reqUpdateQuestionDto);
@@ -54,18 +50,8 @@ public class QuestionService {
                 .orElseThrow(() -> new ResourceNotFoundException("조회된 질문글이 없습니다."));
     }
 
-    public List<Question> getAllQuestion() {
-        return questionRepository.findAll();
-    }
-
-//    public List<Question> getAllMyQuestion(String user) {
-//        return questionRepository.findByUser(user);
-//    }
 
     public void deleteQuestion(Long questionId) {
-        // 1. userservice에서 유저를 찾아
-        // 2. questionId로 question을 찾아
-        // 3. question의 작성자가 위에 파라미터로 들어온 username인지 확인 -> 다르면 예외 발생
      if(questionRepository.existsById(questionId)){ // throw 로 확실히 예외처리를 하겠습니다.
          questionRepository.deleteById(questionId);
      } else {
@@ -73,31 +59,14 @@ public class QuestionService {
      }
     }
 
-    /* Completed 된 Question의 글 중에서 페이징 수를 가져오는 부분 ...  */
-    /*  Pageable 인터페이스
-    getPagenumber() 현재 페이지 번호를 반환, getPageSize()한 페이지당 최대 항목수, getOffset()현재 페이지의 시작위치,
-    getSort() 정렬정보, next() 다음 페이지 정보, previous()이전 페이지 번호
-    getContent() */
-
     public Page<ResQuestionListDto> getQuestionList(int pageNum, int listSize) {
         Pageable pageable = PageRequest.of(pageNum-1, listSize, Sort.by("date").descending());
         Page<Question> questions = questionRepository.findAll(pageable);
 
         Page<ResQuestionListDto> resQuestionDtoList = questions.map(ResQuestionListDto::toDto);
-            /*
-        each-for 문 사용법
-        for (type 변수명: iterate) {
-            body-of-loop }
-       */
-//        for (Question question : questions) {
-//            ResQuestionListDto resQuestionListDto = ResQuestionListDto.toDto(question);
-//            resQuestionDtoList.add(resQuestionListDto);
-//        }
         return resQuestionDtoList;
     }
 
-    // 나의 정보 불러오기는 pageable에다가 criteria 을 함께 넣어주면 됨..! 에서 userName을 찾아와서 찾아주는 방식으로 구현할 생각이었으나,
-    // question에서는 게시글을 username으로 저장하므로... 그냥 바로 questionRepository.findByUser에서 찾아와도 될듯... ?
 
     public List<ResQuestionListDto> getMyQuestionList(String userName, int pageNum, int listSize) {
         User user = userService.findByEmail(userName);
@@ -106,11 +75,7 @@ public class QuestionService {
         questions.getContent();
         questions.getTotalElements();
         questions.getTotalPages();
-        /*
-        each-for 문 사용법
-        for (type 변수명: iterate) {
-            body-of-loop }
-       */
+
         List<ResQuestionListDto> resQuestionList = new ArrayList<>();
         for(Question question : questions.getContent()) {
             resQuestionList.add(ResQuestionListDto.toDto(question));

--- a/dataportal-web/src/main/java/com/hanyang/dataportal/qna/service/QuestionService.java
+++ b/dataportal-web/src/main/java/com/hanyang/dataportal/qna/service/QuestionService.java
@@ -38,6 +38,7 @@ public class QuestionService {
     public Question updateQuestion(Question reqUpdateQuestionDto, long questionId) {
         Optional<Question> updateQuestion = questionRepository.findById(questionId);
         if (updateQuestion.isPresent()) {
+            reqUpdateQuestionDto.setId(questionId);
             questionRepository.save(reqUpdateQuestionDto);
         } else {
             throw new ResourceNotFoundException("수정할 질문글이 없습니다.");


### PR DESCRIPTION
 **my/list 경로에서 userDetails 값이 NULL로 반환되는 문제** 

JwtAuthenticationFilter 상 코드에서 shouldNotFilter 클래스에 경로가 입력될 경우 UserDetail 어노테이션에서 Null로 반환하고 시작하여서 발행하는 문제이었습니다. 
   protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
        final String[] excludes = {
                "/api/user/login",
                "/api/user/signup",
                "/api/user/token",
                "/api/dataset",
                "/api/datasets",
                "/api/notices/list",
        };
        final String path = request.getRequestURI();
        return Arrays.stream(excludes).anyMatch(path::startsWith);
    }

**Question 로직에서 게시글 수정시 신규 생성되는 문제** 
   public Question updateQuestion(Question reqUpdateQuestionDto, long questionId) {
        Optional<Question> updateQuestion = questionRepository.findById(questionId);
        if (updateQuestion.isPresent()) {
            **reqUpdateQuestionDto.setId(questionId);** 
            questionRepository.save(reqUpdateQuestionDto);
        } else {
            throw new ResourceNotFoundException("수정할 질문글이 없습니다.");
        }
        return reqUpdateQuestionDto;
    }

파라미터 값으로 넘어왔던 questionId를 updateQuestion 인스턴스에 넣지 않고
save를 하고 있었습니다. 문제를 해결하였습니다. 

<img width="988" alt="스크린샷 2024-05-06 오후 8 42 21" src="https://github.com/ckan-project/ckan-back/assets/25243469/8f75756b-8fc5-4627-a2ff-9dd39ca726ef">

<img width="1422" alt="스크린샷 2024-05-06 오후 8 42 31" src="https://github.com/ckan-project/ckan-back/assets/25243469/143be04b-1c24-49f8-a605-682c11a6a706">

